### PR TITLE
Manage update URL extra parameters

### DIFF
--- a/src/files/ddns-updater
+++ b/src/files/ddns-updater
@@ -207,6 +207,11 @@ class ddnsUpdater(object):
             else:
                 wildcard = None
 
+            if ( self.__configParser.has_option(self.__profile, 'extra_parameters')):
+                extra_parameters = self.__configParser.get(self.__profile, 'extra_parameters')
+            else:
+                extra_parameters = None
+
             ## Set up the HTTPS connection
             connection = HTTPSConnection(server)
 
@@ -231,6 +236,9 @@ class ddnsUpdater(object):
 
             if ( wildcard != None and wildcard != '' ):
                 parameters = parameters +'&wildcard='+ wildcard
+
+            if ( extra_parameters != None and extra_parameters != '' ):
+                parameters = parameters + '&' + extra_parameters
 
             ## Start update
             connection.request('GET', serverPath +'?'+ parameters, headers=headers)

--- a/src/files/ddns.conf
+++ b/src/files/ddns.conf
@@ -19,6 +19,9 @@ hostname = <hostname>
 ## Domain wildcard (optional!)
 #wildcard = NOCHG
 
+## Update URL extra parameters (optional!). Will be prepended a & and added as is to the URL.
+#extra_parameters = system=dyndns
+
 ## Note: Do not edit this! It will be updated automatically
 ip =
 


### PR DESCRIPTION
Some providers, at least OVH and Gandi, require system=dyndns querystring
parameter.