### PR TITLE
Disable cron job email sendings

### DIFF
--- a/src/debian/ddns-updater.cron.d
+++ b/src/debian/ddns-updater.cron.d
@@ -1,2 +1,2 @@
 ## Start DDNS Updater every 10 minutes
-*/10 * * * * root /usr/sbin/ddns-updater
+*/10 * * * * root /usr/sbin/ddns-updater > /dev/null 2>&1


### PR DESCRIPTION
By default cron sends jobs outputs by email to the job's owner. Disabling
it to handle email notifications through ddns-updater only.